### PR TITLE
Fix: Ctrl+C closes the experiment gracefully on Windows

### DIFF
--- a/azureml_ngc_tools/AzureMLComputeCluster.py
+++ b/azureml_ngc_tools/AzureMLComputeCluster.py
@@ -6,7 +6,6 @@ from .utils.port_forward_utils import port_forward_logger
 
 import time, os, subprocess, logging
 import pathlib
-import signal
 
 logger = logging.getLogger("azureml_ngc")
 
@@ -257,8 +256,6 @@ class AzureMLComputeCluster:
         self.__update_links()
 
         self.__print_message("Connections established")
-        # while True:
-        #     a = 0
 
     def __update_links(self):
         hostname = "localhost"
@@ -298,7 +295,7 @@ class AzureMLComputeCluster:
         ### Starting thread to keep the SSH tunnel open on Windows
         self.portforward_logg = port_forward_logger(self.portforward_proc)
         self.portforward_logg.start()
-        
+
     @property
     def jupyter_link(self):
         """ Link to JupyterLab on running on the headnode of the cluster.

--- a/azureml_ngc_tools/cli/azureml_ngc.py
+++ b/azureml_ngc_tools/cli/azureml_ngc.py
@@ -167,13 +167,19 @@ def start(login, app):
         experiment_name=login_config["aml_compute"]["exp_name"],
         environment_definition=env,
         jupyter_port=login_config["aml_compute"]["jupyter_port"],
-        telemetry_opt_out=True,
+        telemetry_opt_out=login_config["azureml_user"]["telemetry_opt_out"],
         admin_username=login_config["aml_compute"]["admin_name"],
         admin_ssh_key=pri_key_file,
     )
 
     logger.info(f"\n    Go to: {amlcluster.jupyter_link}")
     logger.info("    Press Ctrl+C to stop the cluster.")
+
+    try:
+        while True:
+          pass
+    except KeyboardInterrupt:
+        amlcluster.close()
 
 
 def get_ssh_keys():

--- a/azureml_ngc_tools/cli/azureml_ngc.py
+++ b/azureml_ngc_tools/cli/azureml_ngc.py
@@ -177,7 +177,7 @@ def start(login, app):
 
     try:
         while True:
-          pass
+            pass
     except KeyboardInterrupt:
         amlcluster.close()
 

--- a/azureml_ngc_tools/utils/port_forward_utils.py
+++ b/azureml_ngc_tools/utils/port_forward_utils.py
@@ -1,6 +1,8 @@
 import threading
+
+
 class port_forward_logger(threading.Thread):
-    def  __init__(self, portforward_proc):
+    def __init__(self, portforward_proc):
         super().__init__()
 
         self.portforward_proc = portforward_proc
@@ -16,7 +18,7 @@ class port_forward_logger(threading.Thread):
                 self.portforward_log.flush()
 
         return
-            
+
     def join(self, timeout=None):
         self.running = False
         self.stop_logging.set()

--- a/azureml_ngc_tools/utils/port_forward_utils.py
+++ b/azureml_ngc_tools/utils/port_forward_utils.py
@@ -1,0 +1,23 @@
+import threading
+class port_forward_logger(threading.Thread):
+    def  __init__(self, portforward_proc):
+        super().__init__()
+
+        self.portforward_proc = portforward_proc
+        self.portforward_log = open("portforward_out_log.txt", "w")
+        self.stop_logging = threading.Event()
+        self.running = True
+
+    def run(self):
+        while self.running:
+            portforward_out = self.portforward_proc.stdout.readline()
+            if self.portforward_proc != "":
+                self.portforward_log.write(portforward_out)
+                self.portforward_log.flush()
+
+        return
+            
+    def join(self, timeout=None):
+        self.running = False
+        self.stop_logging.set()
+        super().join(timeout)

--- a/config/login.json
+++ b/config/login.json
@@ -3,7 +3,8 @@
     {
         "subscription_id": "<YOUR-SUBSCRIPTION-ID>",
         "resource_group": "<YOUR-RESOURCE-GROUP>",
-        "workspace_name": "<YOUR-WORKSPACE-NAME>"
+        "workspace_name": "<YOUR-WORKSPACE-NAME>",
+        "telemetry_opt_out": <true|false>
     },
     "aml_compute":
     {


### PR DESCRIPTION
Ctrl+C via `signal` worked fine on POSIX systems but not on NT. Changes implemented removed signal and replaced with infinite loop and KeyboardInterrupt handler.