### PR TITLE
Adding DASK support and enabling github download/upload

### DIFF
--- a/config/ngc_app.json
+++ b/config/ngc_app.json
@@ -10,7 +10,8 @@
                 "filename": <FILENAME_TO_SAVE_TO>,
                 "localdirectory": <DIRECTORY_TO_EXTRACT_CONTENTS>,
                 "computedirectory": <DIRECTORY_TO_UPLOAD_CONTENTS>,
-                "zipped": <false|true>
+                "zipped": <false|true>,
+                "source": <github>
             },
             ...
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 azureml-sdk>=1.0.83
 click>=7.1.2
 tqdm>=4.48.0
+dask-cloudprovider>=0.4.1


### PR DESCRIPTION
After figuring out the RAPIDS container needed to be extended to include mpi4py and azureml--sdk. I was able to test adding support for the DASK cluster using dask-cloudprovider, Decided to leave original code for singular node without DASK to reduce the possible sources of problems that could crash the deployments. Also adding support for download/upload from github sources

I fully tested the branch from scratch built and ran azureml-ngc-tools and it worked as expected